### PR TITLE
Only run keygrabber if it's not running already.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -377,59 +377,61 @@ local function switch(dir, alt, tab, shift_tab)
 
    -- Now that we have collected all windows, we should run a keygrabber
    -- as long as the user is alt-tabbing:
-   keygrabber.run(
-      function (mod, key, event)  
-	 -- Stop alt-tabbing when the alt-key is released
-	 if key == alt or key == "Escape" and event == "release" then
-	    preview_wbox.visible = false
-	    applyOpacity = false
-	    preview_live_timer:stop()
-	    previewDelayTimer:stop()
-	    opacityDelayTimer:stop()
-   
-	    if key == "Escape" then 
-	       for i,c in pairs(altTabTable) do
-		  c.opacity = altTabOpacity[i]
-	       end
-	       keygrabber.stop()
-	       return
-	    end
+   if(keygrabber.isrunning() == false) then
+       keygrabber.run(
+          function (mod, key, event)  
+         -- Stop alt-tabbing when the alt-key is released
+         if key == alt or key == "Escape" and event == "release" then
+            preview_wbox.visible = false
+            applyOpacity = false
+            preview_live_timer:stop()
+            previewDelayTimer:stop()
+            opacityDelayTimer:stop()
+       
+            if key == "Escape" then 
+               for i,c in pairs(altTabTable) do
+              c.opacity = altTabOpacity[i]
+               end
+               keygrabber.stop()
+               return
+            end
 
-	    -- Raise clients in order to restore history
-	    local c
-	    for i = 1, altTabIndex - 1 do
-	       c = altTabTable[altTabIndex - i]
-	       if not altTabMinimized[i] then
-		  c:raise()
-		  client.focus = c
-	       end
-	    end
+            -- Raise clients in order to restore history
+            local c
+            for i = 1, altTabIndex - 1 do
+               c = altTabTable[altTabIndex - i]
+               if not altTabMinimized[i] then
+              c:raise()
+              client.focus = c
+               end
+            end
 
-	    -- raise chosen client on top of all
-	    c = altTabTable[altTabIndex]
-	    c:raise()
-	    client.focus = c                  
+            -- raise chosen client on top of all
+            c = altTabTable[altTabIndex]
+            c:raise()
+            client.focus = c                  
 
-	    -- restore minimized clients
-	    for i = 1, #altTabTable do
-	       if i ~= altTabIndex and altTabMinimized[i] then 
-		  altTabTable[i].minimized = true
-	       end
-	       altTabTable[i].opacity = altTabOpacity[i]
-	    end
+            -- restore minimized clients
+            for i = 1, #altTabTable do
+               if i ~= altTabIndex and altTabMinimized[i] then 
+              altTabTable[i].minimized = true
+               end
+               altTabTable[i].opacity = altTabOpacity[i]
+            end
 
-	    keygrabber.stop()
+            keygrabber.stop()
 
-      	    -- Move to next client on each Tab-press
-	 elseif (key == tab or key == "Right") and event == "press" then
-	    altTabIndex = cycle(altTabTable, altTabIndex, 1)
-	    
-      	    -- Move to previous client on Shift-Tab
-	 elseif (key == shift_tab or key == "Left") and event == "press" then
-	    altTabIndex = cycle(altTabTable, altTabIndex, -1)
-	 end
-      end
-   )
+                -- Move to next client on each Tab-press
+         elseif (key == tab or key == "Right") and event == "press" then
+            altTabIndex = cycle(altTabTable, altTabIndex, 1)
+            
+                -- Move to previous client on Shift-Tab
+         elseif (key == shift_tab or key == "Left") and event == "press" then
+            altTabIndex = cycle(altTabTable, altTabIndex, -1)
+         end
+          end
+       )
+   end
 
    -- switch to next client
    altTabIndex = cycle(altTabTable, altTabIndex, dir)


### PR DESCRIPTION
Added a check before running the keygrabber.
- Attempting to run the keygrabber while it's already running yields an error.